### PR TITLE
ci: add Redis service to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,16 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Add Redis service to the release workflow so Redis integration tests can pass.

## Problem

The release workflow runs `bun test` which automatically sets `CI=true`. This enables the Redis integration tests (`describe.skipIf(!isCI)`), but there was no Redis server available, causing all 25 Redis tests to fail with connection errors.

## Solution

Add the same Redis service configuration that the CI workflow uses:

```yaml
services:
  redis:
    image: redis:7
    ports:
      - 6379:6379
```

## Test plan

- [x] Matches CI workflow configuration
- [ ] Release workflow tests should pass after merge