### PR TITLE
fix(ci): add pnpm install for workspace protocol resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run tests
         run: bun test
 
+      - name: Install dependencies with pnpm (for workspace protocol resolution)
+        run: pnpm install
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- Fixes the release workflow failing with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL`
- Adds `pnpm install` step before publishing so pnpm can resolve `workspace:*` dependencies

## Root Cause
pnpm needs its own dependency install to resolve workspace protocol. Using `bun install` alone doesn't provide pnpm with the workspace dependency graph needed to convert `workspace:*` → `^x.y.z` during publish.

## Test plan
- [ ] Verify release workflow completes successfully
- [ ] Check published packages have proper semver dependencies